### PR TITLE
Update CustomerLoginQuoteSync.php

### DIFF
--- a/src/Spryker/Client/PersistentCart/QuoteStorageSynchronizer/CustomerLoginQuoteSync.php
+++ b/src/Spryker/Client/PersistentCart/QuoteStorageSynchronizer/CustomerLoginQuoteSync.php
@@ -124,7 +124,7 @@ class CustomerLoginQuoteSync implements CustomerLoginQuoteSyncInterface
      */
     protected function isDatabaseStorageStrategy(string $strategyName): bool
     {
-        return $strategyName !== static::STORAGE_STRATEGY_DATABASE;
+        return $strategyName === static::STORAGE_STRATEGY_DATABASE;
     }
 
     /**


### PR DESCRIPTION
The comparison doesn't match the name of the method and it apparently is wrong

## PR Description

When investigating an issue that was raised in line 91 of the CustomerLoginQuoteSync.php I found that according to the test before $this->isDatabaseStorageStrategy($this->quoteClient->getStorageStrategy()) it should not have been called at all since we are using database storage and checking the code of the method it seems like the comparison is wrong.

## Checklist
- [ x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
